### PR TITLE
fix for rails 4.1

### DIFF
--- a/lib/rails/dummy/generator.rb
+++ b/lib/rails/dummy/generator.rb
@@ -1,13 +1,13 @@
 require 'rails/generators'
-require 'rails/generators/rails/plugin_new/plugin_new_generator'
+require 'rails/generators/rails/plugin/plugin_generator'
 require 'rails/dummy/version'
 
 module Rails
   module Dummy
 
-    class Generator < Rails::Generators::PluginNewGenerator
+    class Generator < Rails::Generators::PluginGenerator
       def self.default_source_root
-        Rails::Generators::PluginNewGenerator.default_source_root
+        Rails::Generators::PluginGenerator.default_source_root
       end
 
       def do_nothing

--- a/rails-dummy.gemspec
+++ b/rails-dummy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails"
+  spec.add_dependency "rails", ">= 4.1.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Changes based on https://github.com/rails/rails/commit/ec8d8652f36bc4bf2ea19b8f7dd264187efc99ae commit. rails-dummy work fine for rails to 4.0.x but for 4.1.0 it not work.
