### PR TITLE
Fix "db:test:prepare is deprecated" message for Rails >= 4.1

### DIFF
--- a/lib/tasks/dummy.rake
+++ b/lib/tasks/dummy.rake
@@ -47,7 +47,8 @@ namespace :dummy do
   task :migrate do
     # File.expand_path is executed directory of generated Rails app
     rakefile = File.expand_path('Rakefile', dummy_path)
-    command = "rake -f '%s' db:migrate db:test:prepare" % rakefile
+    command = "rake -f '%s' db:migrate" % rakefile
+    command << " db:test:prepare" if ::Rails::VERSION::STRING.to_f < 4.1 
     sh(command) unless ENV["DISABLE_MIGRATE"]
   end
 

--- a/spec/tasks/dummy_migrate_spec.rb
+++ b/spec/tasks/dummy_migrate_spec.rb
@@ -18,8 +18,9 @@ describe 'dummy:migrate' do
     end
   end
 
-  context 'when DISABLE_MIGRATE variable is not set' do
+  context 'when DISABLE_MIGRATE variable is not set (pre RAILS 4.1)' do
     before do
+      stub_const("::Rails::VERSION::STRING", 3.2)
       rakefile = File.expand_path('../../dummy/Rakefile', __FILE__)
       command = "rake -f '%s' db:migrate db:test:prepare" % rakefile
       # An equivalent of mocking `sh` method
@@ -27,6 +28,20 @@ describe 'dummy:migrate' do
     end
 
     it 'calls rake with db:migrate db:test:prepare task' do
+      task.invoke
+    end
+  end
+
+  context 'when DISABLE_MIGRATE variable is not set (post RAILS 4.1)' do
+    before do
+      stub_const("::Rails::VERSION::STRING", 4.1)
+      rakefile = File.expand_path('../../dummy/Rakefile', __FILE__)
+      command = "rake -f '%s' db:migrate" % rakefile
+      # An equivalent of mocking `sh` method
+      Rake::AltSystem.should_receive(:system).with(command).and_return(true)
+    end
+
+    it 'calls rake with db:migrate task' do
       task.invoke
     end
   end


### PR DESCRIPTION
I don't like the way it's fixed but even rspec-rails uses this method: rspec/rspec-rails#946
